### PR TITLE
Reduce num of features enabled for dep tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,31 +510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
 name = "pegasus"
 version = "0.1.0"
 dependencies = [
@@ -898,12 +873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
-name = "smallvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
 name = "spin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,7 +939,6 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "pegasus"
 version = "0.1.0"
 dependencies = [
@@ -873,6 +898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
 name = "spin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +970,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 openssh = "0.8.1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "macros", "io-util", "time", "sync", "rt-multi-thread"] }
 futures = "0.3"
 flume = { version = "0.10.10", features = ["async"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 openssh = "0.8.1"
-tokio = { version = "1", features = ["rt", "macros", "io-util", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "macros", "io-util", "time", "sync", "rt-multi-thread", "parking_lot"] }
 futures = "0.3"
 flume = { version = "0.10.10", features = ["async"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Avoid pulling feature `io-std`, [`net`], [`signal`] and `fs`, which added bloat to the binary that are completely unused.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

[`net`]: https://docs.rs/crate/tokio/latest/features#net
[`signal`]: https://docs.rs/crate/tokio/latest/features#signal